### PR TITLE
Google and MS Identity organisation id 

### DIFF
--- a/client/src/main/java/dk/acto/fafnir/client/JwtAuthentication.java
+++ b/client/src/main/java/dk/acto/fafnir/client/JwtAuthentication.java
@@ -92,4 +92,10 @@ public class JwtAuthentication implements Authentication, UserDetails {
         return Optional.ofNullable(details)
                 .map(FafnirUser::getMetaId).isPresent();
     }
+
+    public boolean isInOrganisation() {
+        return Optional.ofNullable(details)
+                .map(FafnirUser::getOrganisationId)
+                .isPresent();
+    }
 }

--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,8 @@ These are (Environment variables marked with :heavy_check_mark: are **required**
 * Google
     * GOOGLE_AID - The Google Application Id :heavy_check_mark:
     * GOOGLE_SECRET - The Google Secret :heavy_check_mark:
-* Microsoft Identity
+* Microsoft Identity  
+    As Fafnir is using OpenID Connect to authenticate, you need to check the "ID tokens" box under "Implicit grant and hybrid flows" in the Authentication menu. If this box is not checked, you will receive an error upon authentication.
     * MSID_AID - The Azure App Application ID :heavy_check_mark:
     * MSID_SECRET - The Azure App Client Secret :heavy_check_mark:
     * MSID_TENANT - The Azure App's chosen [tenancy](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols#endpoints) :heavy_check_mark:

--- a/webservice/src/main/java/dk/acto/fafnir/server/BeanConf.java
+++ b/webservice/src/main/java/dk/acto/fafnir/server/BeanConf.java
@@ -193,7 +193,8 @@ public class BeanConf {
         return Try.of(() -> new ServiceBuilder(msIdentityConf.getAppId())
                 .apiSecret(msIdentityConf.getSecret())
                 .callback(fafnirConf.getUrl() + "/msidentity/callback")
-                .defaultScope("user.read")
+                .responseType("id_token code")
+                .defaultScope("openid user.read")
                 .build(new MicrosoftIdentityApi(msIdentityConf.getTenant()))).getOrNull();
     }
 }

--- a/webservice/src/main/java/dk/acto/fafnir/server/provider/AppleProvider.java
+++ b/webservice/src/main/java/dk/acto/fafnir/server/provider/AppleProvider.java
@@ -32,7 +32,7 @@ public class AppleProvider implements RedirectingAuthenticationProvider<TokenCre
 
     @Override
     public CallbackResult callback(TokenCredentials data) {
-        var code = data.getToken();
+        var code = data.getIdToken();
 
         DecodedJWT jwtToken = JWT.decode(code);
         String subject = jwtToken.getClaims().get("sub").asString();

--- a/webservice/src/main/java/dk/acto/fafnir/server/provider/FacebookProvider.java
+++ b/webservice/src/main/java/dk/acto/fafnir/server/provider/FacebookProvider.java
@@ -36,7 +36,7 @@ public class FacebookProvider implements RedirectingAuthenticationProvider<Token
     }
 
     public CallbackResult callback(TokenCredentials data) {
-        var code = data.getToken();
+        var code = data.getCode();
         OAuth2AccessToken token = Option.of(code)
                 .toTry()
                 .mapTry(facebookOauth::getAccessToken)

--- a/webservice/src/main/java/dk/acto/fafnir/server/provider/GoogleProvider.java
+++ b/webservice/src/main/java/dk/acto/fafnir/server/provider/GoogleProvider.java
@@ -34,7 +34,7 @@ public class GoogleProvider implements RedirectingAuthenticationProvider<TokenCr
 
     @Override
     public CallbackResult callback(TokenCredentials data) {
-        var code = data.getToken();
+        var code = data.getCode();
         final OAuth2AccessToken token = Option.of(code)
                 .toTry()
                 .mapTry(googleOauth::getAccessToken)
@@ -52,6 +52,9 @@ public class GoogleProvider implements RedirectingAuthenticationProvider<TokenCr
                 .subject(subject)
                 .provider("google")
                 .name(displayName)
+                .organisationId(!jwtToken.getClaim("hd").isNull()
+                        ? jwtToken.getClaim("hd").asString()
+                        : null)
                 .build());
         return CallbackResult.success(jwt);
     }

--- a/webservice/src/main/java/dk/acto/fafnir/server/provider/LinkedInProvider.java
+++ b/webservice/src/main/java/dk/acto/fafnir/server/provider/LinkedInProvider.java
@@ -40,7 +40,7 @@ public class LinkedInProvider implements RedirectingAuthenticationProvider<Token
 	}
 
 	public CallbackResult callback(TokenCredentials data) {
-		var code = data.getToken();
+		var code = data.getCode();
 		OAuth2AccessToken token = Option.of(code)
 				.toTry()
 				.mapTry(linkedInOAuth::getAccessToken)

--- a/webservice/src/main/java/dk/acto/fafnir/server/provider/MicrosoftIdentityProvider.java
+++ b/webservice/src/main/java/dk/acto/fafnir/server/provider/MicrosoftIdentityProvider.java
@@ -46,8 +46,6 @@ public class MicrosoftIdentityProvider implements RedirectingAuthenticationProvi
 
     @Override
     public CallbackResult callback(TokenCredentials data) {
-        log.info("CODE ::: " + data.getCode());
-
         var code = data.getCode();
         OAuth2AccessToken token = Option.of(code)
                 .toTry()

--- a/webservice/src/main/java/dk/acto/fafnir/server/provider/MicrosoftIdentityProvider.java
+++ b/webservice/src/main/java/dk/acto/fafnir/server/provider/MicrosoftIdentityProvider.java
@@ -1,5 +1,7 @@
 package dk.acto.fafnir.server.provider;
 
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.scribejava.core.model.OAuth2AccessToken;
 import com.github.scribejava.core.model.OAuthRequest;
@@ -17,6 +19,9 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
+import java.security.SecureRandom;
+import java.util.Map;
+
 @Log4j2
 @Lazy
 @Component
@@ -27,17 +32,23 @@ public class MicrosoftIdentityProvider implements RedirectingAuthenticationProvi
     private final OAuth20Service microsoftIdentityOauth;
 
     private static final String MS_GRAPH_ME = "https://graph.microsoft.com/v1.0/me";
+    // From: https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens
+    private static final String PERSONAL_TENANT_GUID = "9188040d-6c67-4c5b-b112-36a304b66dad";
+    private final SecureRandom random = new SecureRandom();
 
     @Override
     public String authenticate() {
-        return microsoftIdentityOauth.getAuthorizationUrl();
+        return microsoftIdentityOauth.getAuthorizationUrl(Map.of(
+                "nonce", String.valueOf(random.nextInt()),
+                "response_mode", "form_post"
+        ));
     }
 
     @Override
     public CallbackResult callback(TokenCredentials data) {
-        log.info("CODE ::: " + data.getToken());
+        log.info("CODE ::: " + data.getCode());
 
-        var code = data.getToken();
+        var code = data.getCode();
         OAuth2AccessToken token = Option.of(code)
                 .toTry()
                 .mapTry(microsoftIdentityOauth::getAccessToken)
@@ -63,10 +74,14 @@ public class MicrosoftIdentityProvider implements RedirectingAuthenticationProvi
             return CallbackResult.failure(FailureReason.AUTHENTICATION_FAILED);
         }
 
+        var id = JWT.decode(data.getIdToken());
+        var tenantId = id.getClaim("tid").asString();
+
         String jwt = tokenFactory.generateToken(FafnirUser.builder()
                 .subject(subject)
                 .provider("msidentity")
                 .name(name)
+                .organisationId(tenantId.equals(PERSONAL_TENANT_GUID) ? null : tenantId)
                 .build());
 
         return CallbackResult.success(jwt);

--- a/webservice/src/main/java/dk/acto/fafnir/server/provider/MitIdProvider.java
+++ b/webservice/src/main/java/dk/acto/fafnir/server/provider/MitIdProvider.java
@@ -42,7 +42,7 @@ public class MitIdProvider implements RedirectingAuthenticationProvider<TokenCre
 
     @Override
     public CallbackResult callback(TokenCredentials data) {
-        var code = data.getToken();
+        var code = data.getCode();
         final OAuth2AccessToken token = Option.of(code)
                 .toTry()
                 .mapTry(mitIdOauth::getAccessToken)

--- a/webservice/src/main/java/dk/acto/fafnir/server/provider/credentials/TokenCredentials.java
+++ b/webservice/src/main/java/dk/acto/fafnir/server/provider/credentials/TokenCredentials.java
@@ -8,5 +8,6 @@ import lombok.Value;
 @Builder
 @AllArgsConstructor
 public class TokenCredentials {
-    String token;
+    String code;
+    String idToken;
 }

--- a/webservice/src/main/java/dk/acto/fafnir/server/service/controller/AppleController.java
+++ b/webservice/src/main/java/dk/acto/fafnir/server/service/controller/AppleController.java
@@ -28,7 +28,7 @@ public class AppleController {
     @PostMapping("callback")
     public RedirectView callback(@RequestParam("id_token") String code) {
         return new RedirectView(provider.callback(TokenCredentials.builder()
-                .token(code)
+                .idToken(code)
                 .build()).getUrl(fafnirConf));
     }
 

--- a/webservice/src/main/java/dk/acto/fafnir/server/service/controller/FacebookController.java
+++ b/webservice/src/main/java/dk/acto/fafnir/server/service/controller/FacebookController.java
@@ -32,7 +32,7 @@ public class FacebookController {
 	@GetMapping("callback")
 	public RedirectView callback(HttpServletResponse response, @RequestParam String code) {
 		return new RedirectView(provider.callback(TokenCredentials.builder()
-				.token(code)
+				.code(code)
 				.build()).getUrl(fafnirConf));
 	}
 

--- a/webservice/src/main/java/dk/acto/fafnir/server/service/controller/GoogleController.java
+++ b/webservice/src/main/java/dk/acto/fafnir/server/service/controller/GoogleController.java
@@ -31,7 +31,7 @@ public class GoogleController {
 	@GetMapping("callback")
 	public RedirectView callback(@RequestParam String code) {
 		return new RedirectView(provider.callback(TokenCredentials.builder()
-				.token(code)
+				.code(code)
 				.build()).getUrl(fafnirConf));
 	}
 

--- a/webservice/src/main/java/dk/acto/fafnir/server/service/controller/LinkedInController.java
+++ b/webservice/src/main/java/dk/acto/fafnir/server/service/controller/LinkedInController.java
@@ -32,7 +32,7 @@ public class LinkedInController {
 	@GetMapping("callback")
 	public RedirectView callback(HttpServletResponse response, @RequestParam String code) {
 		return new RedirectView(provider.callback(TokenCredentials.builder()
-				.token(code)
+				.code(code)
 				.build()).getUrl(fafnirConf));
 	}
 

--- a/webservice/src/main/java/dk/acto/fafnir/server/service/controller/MicrosoftIdentityController.java
+++ b/webservice/src/main/java/dk/acto/fafnir/server/service/controller/MicrosoftIdentityController.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.view.RedirectView;
@@ -28,10 +29,11 @@ public class MicrosoftIdentityController {
 		return new RedirectView(provider.authenticate());
 	}
 
-	@GetMapping("callback")
-	public RedirectView callback(@RequestParam String code) {
+	@PostMapping("callback")
+	public RedirectView callback(@RequestParam String code, @RequestParam("id_token") String idToken) {
 		return new RedirectView(provider.callback(TokenCredentials.builder()
-				.token(code)
+				.code(code)
+				.idToken(idToken)
 				.build()).getUrl(fafnirConf));
 	}
 

--- a/webservice/src/main/java/dk/acto/fafnir/server/service/controller/MitIdController.java
+++ b/webservice/src/main/java/dk/acto/fafnir/server/service/controller/MitIdController.java
@@ -28,7 +28,7 @@ public class MitIdController {
     @GetMapping("callback")
     public RedirectView callback(@RequestParam String code) {
         return new RedirectView(provider.callback(TokenCredentials.builder()
-                .token(code)
+                .code(code)
                 .build()).getUrl(fafnirConf));
     }
 


### PR DESCRIPTION
MS Identity has been migrated to use OpenID Connect, and Google/MS providers now include a FafnirUser.OrganisationId if they are not personal accounts.